### PR TITLE
Add canton enterprise support

### DIFF
--- a/canton.nix
+++ b/canton.nix
@@ -1,21 +1,26 @@
 { pkgs
 , jdkVersion ? "jdk"
 , version ? { type = "open-source"; number = "2.5.5"; }
+, useEnterprise ? false
 , cantonSource ? {
     url = "https://github.com/digital-asset/daml/releases/download/v${version.number}/canton-open-source-${version.number}.tar.gz";
     sha256 = "111ffm8a4n6jgaw7h83q15z128ixxs66768y1103jqv7pql7jrm3";
   }
+, cantonEnterpriseTarball ? pkgs.requireFile {
+    name = "canton-enterprise-${version.number}.tar.gz";
+    url = "https://digitalasset.jfrog.io/artifactory/canton-enterprise/canton-enterprise-${version.number}.tar.gz";
+    sha256 = "00kisb6pygbqk6y3klzpff06myh44nyw95y7znn7y5v09zb8asxi";
+  }
 }:
 pkgs.stdenvNoCC.mkDerivation {
   name = "canton-${version.type}-${version.number}";
-  src = builtins.fetchurl cantonSource;
+  src = if useEnterprise then cantonEnterpriseTarball else builtins.fetchurl cantonSource;
   nativeBuildInputs = [pkgs.makeWrapper];
-  buildInputs = [pkgs.openjdk];
-  installPhase = ''
-    mkdir -p $out/bin
-    mkdir -p $out/lib
-    cp bin/canton $out/bin
-    makeWrapper ${pkgs.openjdk}/bin/java $out/bin/canton
-    cp -r lib/* $out/lib/
+  buildInputs = [pkgs.${jdkVersion}];
+  installPhase = "mkdir -p $out; cp -r * $out";
+  preFixup = ''
+    # Set CANTON_HOME automatically.
+    mkdir -p $out/nix-support
+    echo export CANTON_HOME=$out > $out/nix-support/setup-hook
   '';
 }

--- a/default.nix
+++ b/default.nix
@@ -22,8 +22,15 @@ let
     inherit (pkgs) lib stdenv nodePackages nodejs;
     jdk = pkgs.${jdkVersion};
   };
+  canton = import ./canton.nix {
+    inherit pkgs jdkVersion;
+  };
+  canton-enterprise = import ./canton.nix {
+    inherit pkgs jdkVersion;
+    useEnterprise = true;
+  };
 in {
-  sdk = sdk;
+  inherit sdk canton canton-enterprise;
   vscode = vscodeWithExtensions;
   jdk = pkgs.${jdkVersion};
   extra = [

--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,7 @@
 { vimMode ? false , extraPackages ? (_:[])
 , system ? builtins.currentSystem
 , jdkVersion ? "jdk"
+, cantonVersion ? { type = "open-source"; number = "2.5.5"; }
 }:
 let
   pkgs = import ./dep/nixpkgs {
@@ -24,13 +25,10 @@ let
   };
   canton = import ./canton.nix {
     inherit pkgs jdkVersion;
-  };
-  canton-enterprise = import ./canton.nix {
-    inherit pkgs jdkVersion;
-    useEnterprise = true;
+    version = cantonVersion;
   };
 in rec {
-  inherit sdk canton canton-enterprise;
+  inherit sdk canton;
   vscode = vscodeWithExtensions;
   jdk = pkgs.${jdkVersion};
   extra = [

--- a/default.nix
+++ b/default.nix
@@ -29,7 +29,7 @@ let
     inherit pkgs jdkVersion;
     useEnterprise = true;
   };
-in {
+in rec {
   inherit sdk canton canton-enterprise;
   vscode = vscodeWithExtensions;
   jdk = pkgs.${jdkVersion};
@@ -38,4 +38,11 @@ in {
       pkgs.nodePackages.typescript-language-server
     ] ++ (extraPackages pkgs);
   inherit pkgs;
-  }
+  shell = pkgs.mkShell {
+    name = "daml-sdk";
+    packages = [
+      sdk
+      vscode
+    ] ++ extra;
+  };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,17 +1,8 @@
-{ vimMode ? false , extraPackages ? (_:[])
+{ vimMode ? false
+, extraPackages ? (_:[])
 , system ? builtins.currentSystem
 , jdkVersion ? "jdk"
 }:
-let
-  pkgs = damlPkgs.pkgs;
-  damlPkgs = import ./default.nix {
-    inherit vimMode extraPackages system jdkVersion;
-  };
-in
-  pkgs.mkShell {
-    name = "daml-sdk";
-    packages = [
-      damlPkgs.sdk
-      damlPkgs.vscode
-    ] ++ damlPkgs.extra;
-  }
+(import ./default.nix {
+  inherit vimMode extraPackages system jdkVersion;
+}).shell


### PR DESCRIPTION
To use canton enterprise
```sh
# Download canton-enterprise from https://digitalasset.jfrog.io/ui/repos/tree/General/canton-enterprise

nix-store --add-fixed sha256 ~/Downloads/canton-enterprise-2.5.5.tar.gz
```