### PR TITLE
Change sdk.extensionSha256 in versions 2.6.4.json

### DIFF
--- a/versions/2.6.4.json
+++ b/versions/2.6.4.json
@@ -1,7 +1,7 @@
 { "sdk":
   { "linuxSha256": "sha256:1cxv1plv6jn83ngv110z76ppngvmvxhj2sn85jqfm3viry66rjab",
     "macSha256": "sha256:0fxw53aiqkq20z179p5i4a1zd0myq0vkvfp1k7hfnws2v6615ss6",
-    "extensionSha256": "sha256-kVHXjuCNqJWKSZRT72Dg3eqf3R8xKo7N+qY9ISyrKHM="
+    "extensionSha256": "sha256-kU8yoQe4mjQqgVbrmucn/ucKaiU7HsrkF36dArzX8Tg="
   },
   "canton":
   { "type": "open-source",


### PR DESCRIPTION
Fixes #10, assuming that `sha256-kU8yoQe4mjQqgVbrmucn/ucKaiU7HsrkF36dArzX8Tg=` is the _correct_ SHA and that _current_ value is a copy-and-paste error from 2.5.5.