### PR TITLE
Fix DAML VS Code extension SHA-256 in 'v2.6.4.json'

### DIFF
--- a/versions/2.6.4.json
+++ b/versions/2.6.4.json
@@ -1,7 +1,7 @@
 { "sdk":
   { "linuxSha256": "sha256:1cxv1plv6jn83ngv110z76ppngvmvxhj2sn85jqfm3viry66rjab",
     "macSha256": "sha256:0fxw53aiqkq20z179p5i4a1zd0myq0vkvfp1k7hfnws2v6615ss6",
-    "extensionSha256": "sha256-kVHXjuCNqJWKSZRT72Dg3eqf3R8xKo7N+qY9ISyrKHM="
+    "extensionSha256": "sha256:kU8yoQe4mjQqgVbrmucn/ucKaiU7HsrkF36dArzX8Tg="
   },
   "canton":
   { "type": "open-source",


### PR DESCRIPTION
Fixes https://github.com/obsidiansystems/nix-daml-sdk/issues/10

This is the same pull request as https://github.com/obsidiansystems/nix-daml-sdk/pull/11