### PR TITLE
Add `dpm`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,7 @@
 { vimMode ? false , extraPackages ? (_:[])
 , system ? builtins.currentSystem
 , jdkVersion ? "jdk"
-, sdkVersion ? "2.6.4"
+, sdkVersion ? "3.4.10"
 , scribeVersion ? "0.1.0"
 , sdkSpec ? builtins.fromJSON(builtins.readFile (./versions + "/${sdkVersion}.json"))
 , cantonEnterprise ? false

--- a/default.nix
+++ b/default.nix
@@ -64,8 +64,8 @@ in rec {
     packages = [
       vscode
       canton
-    ] ++ (pkgs.lib.optional (sdk != null) [])
-      ++ (pkgs.lib.optional (dpm != null) [])
+    ] ++ (pkgs.lib.optional (sdk != null) [sdk])
+      ++ (pkgs.lib.optional (dpm != null) [dpm])
       ++ (pkgs.lib.optional (enableScribe) scribe)
       ++ extra;
   };

--- a/default.nix
+++ b/default.nix
@@ -64,9 +64,9 @@ in rec {
     packages = [
       vscode
       canton
-    ] ++ (pkgs.lib.optional (sdk != null) [sdk])
-      ++ (pkgs.lib.optional (dpm != null) [dpm])
-      ++ (pkgs.lib.optional (enableScribe) scribe)
+      sdk
+      dpm
+    ] ++ (pkgs.lib.optional (enableScribe) scribe)
       ++ extra;
   };
 }

--- a/dpm.nix
+++ b/dpm.nix
@@ -1,0 +1,41 @@
+{ lib
+, stdenv
+, system ? builtins.currentSystem
+, version
+, dpmSpec
+}:
+let
+  dpmTarballs =
+    let
+      baseUrl = os: arch: "https://artifactregistry.googleapis.com/download/v1/projects/da-images/locations/europe/repositories/public-generic/files/dpm-sdk:${version}:dpm-${version}-${os}-${arch}.tar.gz:download?alt=media";
+    in
+    {
+      "x86_64-linux" = {
+        url = baseUrl "linux" "amd64";
+        sha256 = dpmSpec.linuxSha256;
+      };
+      "aarch64-darwin" = {
+        url = baseUrl "darwin" "arm64";
+        sha256 = dpmSpec.macSha256;
+      };
+    };
+  dpmTarball = fetchTarball (dpmTarballs.${system} or (builtins.abort "There is currently no DPM tarball defined for ${system}."));
+in
+  stdenv.mkDerivation {
+    inherit version;
+
+    name = "dpm";
+    src = dpmTarball;
+    buildPhase = "patchShebangs .";
+    installPhase = ''
+      mkdir -p $out/bin
+      cp ./bin/dpm $out/bin/dpm
+    '';
+    nativeBuildInputs = [ ];
+    propagatedBuildInputs = [ ];
+    meta = with lib; {
+      description = "Drop-in replacement for the (now deprecated) Daml Assistant.";
+      homepage = "https://get.digitalasset.com/install";
+      license = licenses.asl20;
+    };
+  }

--- a/shell.nix
+++ b/shell.nix
@@ -2,7 +2,7 @@
 , extraPackages ? (_:[])
 , system ? builtins.currentSystem
 , jdkVersion ? "jdk"
-, sdkVersion ? "2.6.4"
+, sdkVersion ? "3.4.10"
 , sdkSpec ? builtins.fromJSON(builtins.readFile (./versions + "/${sdkVersion}.json"))
 , cantonEnterprise ? false
 , enableScribe ? false

--- a/versions/2.5.5.json
+++ b/versions/2.5.5.json
@@ -1,7 +1,9 @@
 { "sdk":
   { "linuxSha256": "sha256:15q2njifg3bz4iiffn85zjanr34zl4d2zvqjs5nhk3r8wlw79jbn", 
-    "macSha256": "sha256:0jbmxd9v40x9fwhm6499gba34a4hykbkffwl41bvxcb1y5al3hfq",
-    "extensionSha256": "sha256-kVHXjuCNqJWKSZRT72Dg3eqf3R8xKo7N+qY9ISyrKHM="
+    "macSha256": "sha256:0jbmxd9v40x9fwhm6499gba34a4hykbkffwl41bvxcb1y5al3hfq"
+  },
+  "vscodeExtension":
+  { "sha256": "sha256-kVHXjuCNqJWKSZRT72Dg3eqf3R8xKo7N+qY9ISyrKHM="
   },
   "canton":
   { "type": "open-source",

--- a/versions/2.6.4.json
+++ b/versions/2.6.4.json
@@ -1,7 +1,9 @@
 { "sdk":
   { "linuxSha256": "sha256:1cxv1plv6jn83ngv110z76ppngvmvxhj2sn85jqfm3viry66rjab",
-    "macSha256": "sha256:0fxw53aiqkq20z179p5i4a1zd0myq0vkvfp1k7hfnws2v6615ss6",
-    "extensionSha256": "sha256:kU8yoQe4mjQqgVbrmucn/ucKaiU7HsrkF36dArzX8Tg="
+    "macSha256": "sha256:0fxw53aiqkq20z179p5i4a1zd0myq0vkvfp1k7hfnws2v6615ss6"
+  },
+  "vscodeExtension":
+  { "sha256": "sha256:kU8yoQe4mjQqgVbrmucn/ucKaiU7HsrkF36dArzX8Tg="
   },
   "canton":
   { "type": "open-source",

--- a/versions/2.6.5.json
+++ b/versions/2.6.5.json
@@ -1,7 +1,9 @@
 { "sdk":
   { "linuxSha256": "sha256:0fsajsghgawwh4ccxz9rak80p8axlsbs2pj8269hkn6afy7k1z6i",
-    "macSha256": "sha256:0cwchp256i2carp721a2cyqzganqcg3ahzqk0ia4kf4hfrqycc6q",
-    "extensionSha256": "sha256-VL+xYC9KOjQ8EtbkDqa/3+e8o0Bq391a4tDvLO440ug="
+    "macSha256": "sha256:0cwchp256i2carp721a2cyqzganqcg3ahzqk0ia4kf4hfrqycc6q"
+  },
+  "vscodeExtension":
+  { "sha256": "sha256-VL+xYC9KOjQ8EtbkDqa/3+e8o0Bq391a4tDvLO440ug="
   },
   "canton":
   { "type": "open-source",

--- a/versions/2.7.1.json
+++ b/versions/2.7.1.json
@@ -1,7 +1,9 @@
 { "sdk":
   { "linuxSha256": "sha256:1p6qdy06qp994izc0kjvcxi7gslnir5f2bbv5a4wfb2j0hd8aaja",
-    "macSha256": "sha256:1fnawg9y7j0z1b5f29lnz3df7br07i435zai5hmrr90vdyjdnvsl",
-    "extensionSha256": "sha256-i85enALaMCiXxWyAMUCy47jQefrS4z6v/s7nTtXJFA0="
+    "macSha256": "sha256:1fnawg9y7j0z1b5f29lnz3df7br07i435zai5hmrr90vdyjdnvsl"
+  },
+  "vscodeExtension":
+  { "sha256": "sha256-i85enALaMCiXxWyAMUCy47jQefrS4z6v/s7nTtXJFA0="
   },
   "canton":
   { "type": "open-source",

--- a/versions/2.8.0.json
+++ b/versions/2.8.0.json
@@ -1,7 +1,9 @@
 { "sdk":
   { "linuxSha256": "sha256:04wy3qh6baxhla1f2cr2br78rhd7n2p9w4a2xfib860zlsqgdzcs",
-    "macSha256": "sha256:1zzkh35fm6wbmxh4xmmnw0b0lijsjaz4hhf06qpdq7krqxr7r98s",
-    "extensionSha256": "sha256-64bK8Q0r2f6SSmgVUORJGXt2rG165DWh6c8QAUfu+qA="
+    "macSha256": "sha256:1zzkh35fm6wbmxh4xmmnw0b0lijsjaz4hhf06qpdq7krqxr7r98s"
+  },
+  "vscodeExtension":
+  { "sha256": "sha256-64bK8Q0r2f6SSmgVUORJGXt2rG165DWh6c8QAUfu+qA="
   },
   "canton":
   { "type": "open-source",

--- a/versions/3.4.10.json
+++ b/versions/3.4.10.json
@@ -1,0 +1,17 @@
+{
+  "vscodeExtension":
+  { "sha256": "sha256:c+PQcY05wTc44Dj72bNxd4ExJW7gqTKDtwdWsWf0zGE="
+  },
+  "dpm":
+  { "linuxSha256": "sha256:04mdwa1fr22anha7b1b81lzibwasikhjlz274qz03qqjwdcwllra",
+    "macSha256": "sha256:05wmspdgb0nlylcqc10rnq985zmxq7mxs7ra785xhk6x052z1ni6"
+  },
+  "canton":
+  { "type": "open-source",
+   "sha256": "sha256:02rm44kv31dhanv2hj56y8hw5r2hwp4n82n0bjj7izi6hbhg2xcs"
+  },
+  "cantonEnterprise":
+  { "type": "enterprise",
+    "sha256": "sha256:FIXME"
+  }
+}

--- a/versions/3.4.10.json
+++ b/versions/3.4.10.json
@@ -12,6 +12,6 @@
   },
   "cantonEnterprise":
   { "type": "enterprise",
-    "sha256": "sha256:FIXME"
+    "sha256": "sha256:0vb0ym6xlk7l62sy6bi4k1zkv68s44s2pk3xi9ym2syy6z8nbydh"
   }
 }


### PR DESCRIPTION
The standalone daml-sdk's Daml Assistant got discontinued a while back (not sure which version, but can confirm 3.4.10 is one of them), and was replaced by `dpm`.

We do have a need for `dpm` in Obsidian internal projects, so I figured I'd add it here.

As a result of the deprecation, each version spec can now only define either a daml-sdk spec or a dpm spec, so either of these can be nullable and are optionally included in the shell if they are defined. Sample install error for daml-sdk using sdkVersion=3.4.10:

```
daml: HTTP connection failed
  context: Installing extracted SDK release.
  details: HttpExceptionRequest Request {
  host                 = "api.github.com"
  port                 = 443
  secure               = True
  requestHeaders       = [("Accept","application/vnd.github+json"),("User-Agent","Daml-Assistant/0.0")]
  path                 = "/repos/digital-asset/daml/releases"
  queryString          = "?per_page=100"
  method               = "GET"
  proxy                = Nothing
  rawBody              = False
  redirectCount        = 10
  responseTimeout      = ResponseTimeoutMicro 10000000
  requestVersion       = HTTP/1.1
  proxySecureMode      = ProxySecureWithConnect
}
```

I haven't looked into whether we can circumvent this to still get a partial install of the daml-sdk using these more recent versions; but I figured we should be moving away from it at these later daml versions anyhow so maybe disabling it is best.

I also bumped the default version to 3.4.10 in anticipation of maybe moving to dpm if nothing else is blocking us, but we can revert this change if necessary.

Notes:
- In the install script from DA, it runs `dpm bootstrap`. From what I can tell this seems to just pre-install the most recent SDK. But I feel like we can just leave this up to the user after the fact (they can do their own `dpm install <sdk_ver>` ). Works fine for me without bootstrapping. Happy to re-add it though.