### PR TITLE
(hotfix) Add bash to wrapped `daml` command

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -25,7 +25,7 @@ let
     ] ++ pkgs.lib.optional vimMode vscodevim.vim ;
   };
   sdk = import ./sdk.nix {
-    inherit (pkgs) lib stdenv nodePackages nodejs makeWrapper coreutils;
+    inherit (pkgs) lib stdenv nodePackages nodejs makeWrapper coreutils bash;
     jdk = pkgs.${jdkVersion};
     sdkSpec = sdkSpec.sdk // { number = sdkVersion; };
   };

--- a/sdk.nix
+++ b/sdk.nix
@@ -23,8 +23,6 @@ in
     buildPhase = "patchShebangs .";
     installPhase = ''
       DAML_HOME=$out ./install.sh ${extra-args}
-      wrapProgram $out/bin/daml \
-        --set PATH ${lib.makeBinPath [ jdk coreutils ]}
     '';
     nativeBuildInputs = [ makeWrapper ];
     propagatedBuildInputs = [ jdk nodePackages.npm nodejs ];

--- a/sdk.nix
+++ b/sdk.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, jdk, nodePackages, nodejs
+{ lib, stdenv, jdk, nodePackages, nodejs, bash
 , sdkSpec
 , makeWrapper
 , coreutils
@@ -23,6 +23,8 @@ in
     buildPhase = "patchShebangs .";
     installPhase = ''
       DAML_HOME=$out ./install.sh ${extra-args}
+      wrapProgram $out/bin/daml \
+        --set PATH ${lib.makeBinPath [ jdk bash coreutils ]}
     '';
     nativeBuildInputs = [ makeWrapper ];
     propagatedBuildInputs = [ jdk nodePackages.npm nodejs ];


### PR DESCRIPTION
`daml start` was throwing the following due to `sh` not being in the wrapped binpath:
```
Failed to start java. Make sure it is installed and in the PATH.
Failed to start java. Make sure it is installed and in the PATH.
..daml-helper: sh: rawSystem: posix_spawnp: does not exist (No such file or directory)
```
